### PR TITLE
Require the queue host to be passed as a parameter

### DIFF
--- a/api/deploy_template.yaml
+++ b/api/deploy_template.yaml
@@ -79,4 +79,4 @@ parameters:
 - name: QUEUE_HOST
   displayName: Message Queue Hostname
   description: Hostname which will be used to contact the message queue.
-  value: approval-kafka
+  required: true


### PR DESCRIPTION
The default would cause issues if it were deployed to production