### PR TITLE
Add the DATABASE_URL as an environment variable to deployment configs

### DIFF
--- a/api/deploy_template.yaml
+++ b/api/deploy_template.yaml
@@ -39,19 +39,15 @@ objects:
           ports:
           - containerPort: 3000
           env:
-          - name: DATABASE_USER
-            value: root
-          - name: DATABASE_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: approval-database-secrets
-                key: database-password
-          - name: DATABASE_NAME
-            value: approval_production
           - name: DATABASE_HOST
             value: approval-postgresql
           - name: DATABASE_PORT
             value: "5432"
+          - name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: approval-database-secrets
+                key: database-url
           - name: QUEUE_HOST
             value: ${QUEUE_HOST}
           - name: QUEUE_NAME

--- a/database/secret_template.yaml
+++ b/database/secret_template.yaml
@@ -13,6 +13,7 @@ objects:
       app: approval
   stringData:
     database-password: "${DATABASE_PASSWORD}"
+    database-url: postgresql://root:${DATABASE_PASSWORD}@approval-postgresql:5432/approval_production?encoding=utf8&pool=5&wait_timeout=5
 parameters:
 - name: DATABASE_PASSWORD
   displayName: PostgreSQL Password


### PR DESCRIPTION
The URL value will be stored as an entry in the database's secret
object and imported by the deployment configs that need it.

This removes the need to pass in the database user, name, and password
to each individual deployment. The host and port need to remain
so that these pods can wait for the database service to be available