### PR TITLE
Set the memory limit for the api build to 1Gi

### DIFF
--- a/api/build_template.yaml
+++ b/api/build_template.yaml
@@ -17,6 +17,9 @@ objects:
   metadata:
     name: approval-api
   spec:
+    resources:
+      limits:
+        memory: 1Gi
     source:
       type: Git
       git:


### PR DESCRIPTION
This matches the configured limit in the e2e-deploy repo