### PR TITLE
Copy the database secret format from production

### DIFF
--- a/api/deploy_template.yaml
+++ b/api/deploy_template.yaml
@@ -46,14 +46,22 @@ objects:
           - name: APP_NAME
             value: ${APP_NAME}
           - name: DATABASE_HOST
-            value: approval-postgresql
-          - name: DATABASE_PORT
-            value: "5432"
-          - name: DATABASE_URL
             valueFrom:
               secretKeyRef:
-                name: approval-database-secrets
-                key: database-url
+                name: approval-db
+                key: hostname
+          - name: DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: approval-db
+                key: password
+          - name: DATABASE_PORT
+            value: "5432"
+          - name: DATABASE_USER
+            valueFrom:
+              secretKeyRef:
+                name: approval-db
+                key: username
           - name: PATH_PREFIX
             value: ${PATH_PREFIX}
           - name: QUEUE_HOST

--- a/bin/deploy
+++ b/bin/deploy
@@ -24,7 +24,7 @@ function api_secrets_provided() {
 # For us to safely create the secret we need to have either provided a password
 # or not have created the secret yet. This ensures we don't overwrite the existing
 # password with a newly generated one.
-(database_password_provided || secret_missing "approval-database-secrets") && apply_template "database/secret_template.yaml"
+(database_password_provided || secret_missing "approval-db") && apply_template "database/secret_template.yaml"
 (api_secrets_provided || secret_missing "approval-api-secrets") && apply_template "api/secret_template.yaml"
 
 # database

--- a/database/deployment_config.yaml
+++ b/database/deployment_config.yaml
@@ -33,11 +33,14 @@ spec:
           mountPath: "/var/lib/pgsql/data"
         env:
         - name: POSTGRESQL_USER
-          value: root
+          valueFrom:
+            secretKeyRef:
+              name: approval-db
+              key: username
         - name: POSTGRESQL_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: approval-database-secrets
-              key: database-password
+              name: approval-db
+              key: password
         - name: POSTGRESQL_DATABASE
           value: approval_production

--- a/database/secret_template.yaml
+++ b/database/secret_template.yaml
@@ -8,12 +8,13 @@ objects:
 - apiVersion: v1
   kind: Secret
   metadata:
-    name: approval-database-secrets
+    name: approval-db
     labels:
       app: approval
   stringData:
-    database-password: "${DATABASE_PASSWORD}"
-    database-url: postgresql://root:${DATABASE_PASSWORD}@approval-postgresql:5432/approval_production?encoding=utf8&pool=5&wait_timeout=5
+    hostname: approval-postgresql
+    username: root
+    password: "${DATABASE_PASSWORD}"
 parameters:
 - name: DATABASE_PASSWORD
   displayName: PostgreSQL Password


### PR DESCRIPTION
This is needed to ensure that we don't need to change our deployment
configs between CI and PROD environments